### PR TITLE
Fix print format in load_and_run_ddr()

### DIFF
--- a/boot/bootmain.c
+++ b/boot/bootmain.c
@@ -108,7 +108,7 @@ void load_and_run_ddr(struct spi_flash* spi_flash,int mode)
 	addr = DEFAULT_DDR_ADDR;
 
 	ret = load_data(spi_flash,addr,DEFAULT_DDR_OFFSET,mode);
-	printk("bootloader version:%s\n\n",VERSION);    
+	printk("\r\nbootloader version:%s\r\n",VERSION);    
 	if(!ret)
 	{
 		writel(0x1, 0x2000004); 


### PR DESCRIPTION
Ensure that secondBoot begins printing on a new blank line by first printing '\r\n'.  Then finish printing the version number with '\r\n' instead of '\n\n\'.  This allows ddrinit to start printing on a new line.

![Screenshot from 2021-05-13 17-52-38](https://user-images.githubusercontent.com/313864/118205127-89d95780-b414-11eb-8069-3c4a7dc99cad.png)


