### PR TITLE
Create LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,6 @@
+Copyright (c) 2020 Shanghai StarFive Technology Co., Ltd.
+SPDX-License-Identifier: GPL-2.0-or-later
+
+This code may be used, at your choice, under the terms of the GNU
+General Public License version 2.0 or later, available at
+https://www.gnu.org/licenses


### PR DESCRIPTION
To fully resolve #6, this PR creates LICENSE for GPL 2.0 or later based on the SPDX-License-Identifier in the source files.

Upstream projects like Buildroot would prefer there an explicit LICENSE so this will satisfy that preference:
[[Buildroot] [PATCH] boot/beaglev-secondboot: update to include upstream fixes](http://lists.busybox.net/pipermail/buildroot/2021-June/311896.html)
> Note: it would be nice if a license file were added to the repository with future updates.